### PR TITLE
Enable tests on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.4"
+
+env:
+  - DJANGO_VERSION=1.6.10
+  - DJANGO_VERSION=1.7.4
+  - DJANGO_VERSION=1.8a1
+
+matrix:
+  exclude:
+    - python: "3.4"
+      env: DJANGO_VERSION=1.6.10
+
+install:
+
+  # Standard installation.
+  - "npm install -g npm"
+  - "pip install Django==$DJANGO_VERSION"
+  - "pip install -r requirements.txt"
+  - "pip install ."
+
+  # Used by django-node but not yet specified in its setup.py
+  - "pip install requests"
+
+script: python runtests.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Django React
 ============
 
+[![Build Status](https://travis-ci.org/markfinger/django-react.svg?branch=master)](https://travis-ci.org/markfinger/django-react)
+
 Render and bundle React components from a Django application.
 
 Documentation

--- a/runtests.py
+++ b/runtests.py
@@ -2,12 +2,16 @@ import os
 import sys
 
 import django
-from django.conf import settings
-from django.test.utils import get_runner
+
 
 if __name__ == '__main__':
     os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
-    django.setup()
+    if hasattr(django, 'setup'):  # Only compatible with Django >= 1.7
+        django.setup()
+
+    # For Django 1.6, need to import after setting DJANGO_SETTINGS_MODULE.
+    from django.conf import settings
+    from django.test.utils import get_runner
 
     from django_node import npm
     npm.install(os.path.join(os.path.dirname(__file__), 'tests'))


### PR DESCRIPTION
Note: to fully work this will require you to sign up at travis-ci.org if you haven't already, and then to enable builds for the markfinger/django-react repo.

Rollup of the following changes:

- Adds a .travis.yml config file
- Depend on latest django-node release
- Don't run tests on Python 3.4 + Django 1.6
- Django 1.6.4 compatibility for test runner
- Add build status badge to README