### PR TITLE
Switch to babel from jsx

### DIFF
--- a/django_react/bundles.py
+++ b/django_react/bundles.py
@@ -6,7 +6,7 @@ from .settings import REACT_EXTERNAL
 class ReactBundle(WebpackBundle):
     # Use the JSX loader for files ending in a 'jsx' extension.
     loaders = (
-        {'loader': 'jsx', 'test': '.jsx$'},
+        {'loader': 'babel', 'test': '.jsx$'},
     )
     # Ensure that Webpack's loader resolver will look in Django React's
     # node_modules directory to find the JSX loader

--- a/django_react/package.json
+++ b/django_react/package.json
@@ -11,9 +11,10 @@
   },
   "dependencies": {
     "express": "^4.11.1",
-    "jsx-loader": "git://github.com/markfinger/jsx-loader#427aa8e17c5e54b101bd205a453058f7de6f9f41",
-    "node-jsx": "^0.12.4",
     "react": "^0.12.2",
-    "yargs": "^1.3.3"
+    "yargs": "^1.3.3",
+    "babel": "~4.1.1",
+    "babel-core": "~4.1.1",
+    "babel-loader": "~4.0.0"
   }
 }

--- a/django_react/render_server.js
+++ b/django_react/render_server.js
@@ -3,10 +3,8 @@ var fs = require('fs');
 var argv = require('yargs').argv;
 var express = require('express');
 var React = require('react');
-var nodeJSX = require('node-jsx');
 
-// Support requiring of JSX files
-nodeJSX.install();
+require('babel/register');
 
 var address = argv.address;
 if (address === undefined) {

--- a/django_react/renderer.js
+++ b/django_react/renderer.js
@@ -1,7 +1,8 @@
 var fs = require('fs');
 var argv = require('yargs').argv;
 var React = require('react');
-var nodeJSX = require('node-jsx');
+
+require('babel/register');
 
 var pathToSource = argv.pathToSource;
 if (!pathToSource) {
@@ -11,9 +12,6 @@ if (!pathToSource) {
 if (!fs.existsSync(pathToSource)) {
 	throw new Error('Cannot find the source file "' + pathToSource + '"')
 }
-
-// Install support for requiring JSX files
-nodeJSX.install();
 
 var component = require(pathToSource);
 


### PR DESCRIPTION
Not sure if you want to do this, but I forked it for my own needs and figured it'd be good to create the PR.

This switches django-react from using Facebook's JSX compiler to using [Babel](https://babeljs.io/). It supports JSX just the same, plus a lot more ES6/7 features. Since ES6 is backwards compatible with ES5, this seems like a good solution.