### PR TITLE
Support date/time and decimal objects in props - #9

### DIFF
--- a/django_react/components.py
+++ b/django_react/components.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 from django.template.loader import render_to_string
 from django.contrib.staticfiles import finders
+from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.safestring import mark_safe
 from django.utils import six
 from .exceptions import (
@@ -22,6 +23,7 @@ class ReactComponent(object):
     variable = None
     props_variable = None
     bundle = ReactBundle
+    json_encoder_class = DjangoJSONEncoder
 
     def __init__(self, **kwargs):
         # As we use the subclass's name to generate a number of client-side
@@ -209,7 +211,7 @@ class ReactComponent(object):
             # While rendering templates Django will silently ignore some types of exceptions,
             # so we need to intercept them and raise our own class of exception
             try:
-                self.serialized_props = json.dumps(self.get_props())
+                self.serialized_props = json.dumps(self.get_props(), cls=self.json_encoder_class)
             except (TypeError, AttributeError) as e:
                 six.reraise(PropSerializationError, PropSerializationError(*e.args), sys.exc_info()[2])
         return self.serialized_props

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -1,8 +1,11 @@
+import datetime
+import json
 import os
 import unittest
 import shutil
 from django.conf import settings
 from django.utils.safestring import mark_safe
+from django.utils import timezone
 from django_webpack.exceptions import BundlingError
 from django_react import ReactComponent, ReactBundle, render_component
 from django_react.exceptions import (
@@ -119,6 +122,25 @@ class TestDjangoReact(unittest.TestCase):
         )
         self.assertTrue(
             rendered.endswith('</script>')
+        )
+
+    def test_can_serialize_datetime_values_in_props(self):
+        component = HelloWorld(
+            text='world!',
+            datetime=datetime.datetime(2015, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+            date=datetime.date(2015, 1, 2),
+            time=datetime.time(3, 4, 5),
+        )
+        serialized = component.get_serialized_props()
+        deserialized = json.loads(serialized)
+        self.assertEqual(
+            deserialized,
+            {
+                'text': 'world!',
+                'datetime': '2015-01-02T03:04:05Z',
+                'date': '2015-01-02',
+                'time': '03:04:05',
+            }
         )
 
     def test_component_init_defaults_to_using_window_dot_react(self):


### PR DESCRIPTION
As we are dependent on Django, use the DjangoJSONEncoder to support this.