### PR TITLE
Add a setting to prevent init-time npm install

### DIFF
--- a/django_react/render.py
+++ b/django_react/render.py
@@ -3,7 +3,7 @@ import tempfile
 import importlib
 from django.utils import six
 from django_node import npm, node
-from .settings import NPM_VERSION_REQUIRED, NODE_VERSION_REQUIRED, RENDERER
+from .settings import NPM_VERSION_REQUIRED, NODE_VERSION_REQUIRED, RENDERER, NPM_INSTALL_ON_INIT
 from .exceptions import SourceFileNotFound, RendererImportError
 
 
@@ -11,8 +11,9 @@ from .exceptions import SourceFileNotFound, RendererImportError
 node.ensure_version_gte(NODE_VERSION_REQUIRED)
 npm.ensure_version_gte(NPM_VERSION_REQUIRED)
 
-# Ensure that the required packages have been installed
-npm.install(os.path.dirname(__file__))
+if NPM_INSTALL_ON_INIT:
+    # Ensure that the required packages have been installed
+    npm.install(os.path.dirname(__file__))
 
 # Import the renderer defined in django_react.settings
 renderer_module_import_path = '.'.join(RENDERER.split('.')[:-1])

--- a/django_react/settings.py
+++ b/django_react/settings.py
@@ -92,3 +92,8 @@ PATH_TO_RENDERER_SOURCE = setting_overrides.get(
     'PATH_TO_RENDERER_SOURCE',
     os.path.abspath(os.path.join(os.path.dirname(__file__), 'renderer.js'))
 )
+
+NPM_INSTALL_ON_INIT = setting_overrides.get(
+    'NPM_INSTALL_ON_INIT',
+    True,
+)


### PR DESCRIPTION
In production my running code doesn't have write permissions on itself, so this `npm install` fails. I added a setting to disable it so I can manage npm manually.