### PR TITLE
Fixing packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ VERSION = '0.9.0'
 setup(
     name='django-react',
     version=VERSION,
-    packages=['django_react'],
+    packages=['django_react', 'django_react.services'],
     package_data={
         'django_react': [
             'package.json',


### PR DESCRIPTION
Currently when you follow the README instructions, you get an ImportError because .services isnt included.
This includes the missing module in the installation.