### PR TITLE
Include render service in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(
     package_data={
         'django_react': [
             'package.json',
-            'render_server.js',
-            'renderer.js',
+            'services/render.js',
             'templates/django_react/*.html',
         ]
     },


### PR DESCRIPTION
The render.js was also missing from package_data